### PR TITLE
Fix user updates and queryset typo

### DIFF
--- a/data/logic/user.py
+++ b/data/logic/user.py
@@ -39,10 +39,11 @@ class UserLogic():
             raise EntityNotFound(
                 f"User with code: {user_code} not found"
             )
+        return user
 
     def update(self, user_code, user_data, user_token):
         user = models.User.objects.get_user_by_code(user_code)
-        if __verify_ownership(user_code, user_token):
+        if self.__verify_ownership(user_code, user_token):
             user.username = user_data.get("username")
             user.name = user_data.get("name")
             user.phone_number = user_data.get("phone_number")

--- a/data/manager/customer_input.py
+++ b/data/manager/customer_input.py
@@ -6,7 +6,7 @@ from data.utils.exceptions import DuplicatedRecord, InvalidOperation
 class CustomerInputQuerySet(models.QuerySet):
 
     def get_all(self):
-        return self.filter(status=Status.Active.value)
+        return self.filter(status=Status.ACTIVE.value)
 
     def get_by_code(self, customer_input_code):
         return self.filter(status=Status.ACTIVE.value, customer_input_code=customer_input_code).first()


### PR DESCRIPTION
## Summary
- fix missing return and method call in `UserLogic`
- fix `Status.ACTIVE` typo in `CustomerInputQuerySet`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_684194df3674832081b4c315ae2d2c7d